### PR TITLE
Custom domain patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 composer.phar
 bin/
 vendor/
+/nbproject/

--- a/src/Model/Link.php
+++ b/src/Model/Link.php
@@ -204,7 +204,7 @@ class Link
     public function export()
     {
         $exportFields = [
-            'id', 'title', 'slashtag', 'destination', 'shortUrl', 'domain',
+            'id', 'title', 'slashtag', 'destination', 'shortUrl',
             'status', 'createdAt', 'updatedAt', 'clicks', 'lastClickAt',
             'favourite', 'forwardParameters'
         ];
@@ -216,6 +216,14 @@ class Link
                 $linkArray[$fieldName] = $value;
             }
         }
+        
+        /* Specific code for 'domain': only the domain id has to be exported */
+        if ($this->domain) {
+            $linkArray['domain'] = array(
+                'id' => $this->domain->getId(),
+            );
+        }
+        
         return $linkArray;
     }
 }


### PR DESCRIPTION
Hello :)

First I wanted to thank you for developing this sdk, it will save me a lot of time in the near future!
Also, this is the first time I do a pull request on a project, so I hope I'm doing everything well...

I've been testing the sdk this afternoon, and when I tried to create a short link with a custom domain (which is correctly registered and active on my Rebrandly account), I found that it was in reality created with rebrand.ly default domain.

It seems that the issue is in the export() function of the LinkModel. When creating the array, it contains all the fields of the domain object, but it should contain only the id of the domain. I've tried a quick fix and it works fine, the result being the short link created with my custom domain.

Let me know if you have any question!
Have a good day,
Nicolas
