### PR TITLE
Fixed class typo

### DIFF
--- a/src/Model/Link.php
+++ b/src/Model/Link.php
@@ -135,7 +135,7 @@ class Link
 
     public function setDomain(DomainModel $domain)
     {
-        if (!$domain instanceof Domain) {
+        if (!$domain instanceof DomainModel) {
             $type = gettype($domain);
             $errorText = printf('Expected domain to be an instance of a DomainModel, %s supplied', $type);
             throw new \InvalidArgumentException($errorText);


### PR DESCRIPTION
Hello again :)
There was an error on a class name in the LinkModel ("Domain" instead of "DomainModel"), I fixed it here.